### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,8 @@ udevil (0.4.4-3) UNRELEASED; urgency=medium
   * debian/copyright: use spaces rather than tabs to start continuation
     lines.
   * Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:23:02 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ udevil (0.4.4-3) UNRELEASED; urgency=medium
   * Use secure copyright file specification URI.
   * debian/copyright: use spaces rather than tabs to start continuation
     lines.
+  * Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:23:02 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+udevil (0.4.4-3) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:23:02 +0000
+
 udevil (0.4.4-2) unstable; urgency=medium
 
   * Fix manpage. (Closes: #840842 LP: #1614419)
@@ -18,7 +24,7 @@ udevil (0.4.4-2) unstable; urgency=medium
     + Add raspberrypi_config.patch -- Merge Raspberry Pi config changes.
     They are more specific for Debian.
   * Update debian/copyright.
-  * debian/rules: 
+  * debian/rules:
     + Enable hardening.
     + Install devmon@.service in correct place. (Closes: #799745)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ udevil (0.4.4-3) UNRELEASED; urgency=medium
   * Depend on newer debhelper (>= 9.20160709) rather than dh-systemd.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Drop unnecessary dh arguments: --with=systemd
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:23:02 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ udevil (0.4.4-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
   * Use secure copyright file specification URI.
+  * debian/copyright: use spaces rather than tabs to start continuation
+    lines.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:23:02 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 udevil (0.4.4-3) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Use secure copyright file specification URI.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:23:02 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: udevil
 Section: utils
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
-Build-Depends: debhelper (>= 10), libglib2.0-dev, 
+Build-Depends: debhelper (>= 10), libglib2.0-dev,
  intltool, libudev-dev, dh-systemd (>= 1.5)
 Standards-Version: 4.0.0
 Homepage: https://ignorantguru.github.com/udevil/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
 Build-Depends: debhelper (>= 10), libglib2.0-dev,
- intltool, libudev-dev, dh-systemd (>= 1.5)
+ intltool, libudev-dev
 Standards-Version: 4.0.0
 Homepage: https://ignorantguru.github.com/udevil/
 Vcs-Git: https://github.com/mati75/udevil.git

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: udevil
 Source: https://github.com/IgnorantGuru/udevil/tree/master/packages/
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -12,7 +12,7 @@ License: LGPL-2+
 
 Files: src/device-info.*
 Copyright: 2008 David Zeuthen <david@fubar.dk>
-	   2012 IgnorantGuru <ignorantguru@openmailbox.org>
+           2012 IgnorantGuru <ignorantguru@openmailbox.org>
 License: GPL-3+
 
 Files: po/Makefile.in.in

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --with systemd
+	dh $@
 
 override_dh_auto_install:
 	dh_auto_install

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/IgnorantGuru/udevil/issues
+Bug-Submit: https://github.com/IgnorantGuru/udevil/issues/new
+Repository: https://github.com/IgnorantGuru/udevil.git
+Repository-Browse: https://github.com/IgnorantGuru/udevil


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri.html))
* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text.html))
* Depend on newer debhelper (>= 9.20160709) rather than dh-systemd. ([build-depends-on-obsolete-package](https://lintian.debian.org/tags/build-depends-on-obsolete-package.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Drop unnecessary dh arguments: --with=systemd ([debian-rules-uses-unnecessary-dh-argument](https://lintian.debian.org/tags/debian-rules-uses-unnecessary-dh-argument.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/udevil/55096a4f-8cc1-4452-875d-12816b56ea5a.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/55096a4f-8cc1-4452-875d-12816b56ea5a/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/55096a4f-8cc1-4452-875d-12816b56ea5a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/55096a4f-8cc1-4452-875d-12816b56ea5a/diffoscope)).
